### PR TITLE
Added fallback to default credential provider chain.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@ pom.xml
 .lein-failures
 .lein-deps-sum
 .lein-env
+.lein-repl-history
 /pom.xml.asc
 .lein-plugins

--- a/project.clj
+++ b/project.clj
@@ -4,5 +4,6 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.2.1"]
-                 [com.amazonaws/aws-java-sdk "1.6.1"]]
+                 [com.amazonaws/aws-java-sdk "1.8.9.1" :exclusions [joda-time]]
+                 [joda-time/joda-time "2.2"]]
   :plugins [[codox "0.6.1"]])

--- a/src/aws/sdk/ec2.clj
+++ b/src/aws/sdk/ec2.clj
@@ -27,7 +27,6 @@
            com.amazonaws.services.ec2.model.IamInstanceProfileSpecification
            com.amazonaws.services.ec2.model.Image
            com.amazonaws.services.ec2.model.Instance
-           com.amazonaws.services.ec2.model.InstanceLicenseSpecification
            com.amazonaws.services.ec2.model.InstanceNetworkInterfaceSpecification
            com.amazonaws.services.ec2.model.InstanceState
            com.amazonaws.services.ec2.model.InstanceStateChange
@@ -382,7 +381,6 @@
   (let [mappers
         {
          :iam-instance-profile  (fn [iam-instance-profile]  ((mapper-> IamInstanceProfileSpecification) iam-instance-profile))
-         :license               (fn [license]               ((mapper-> InstanceLicenseSpecification) license))
          :placement             (fn [placement]             ((mapper-> Placement) placement))
          :ebs                   (fn [ebs]                   ((mapper-> EbsBlockDevice) ebs))
          ;; the following attributes contain vectors of maps

--- a/src/aws/sdk/ec2.clj
+++ b/src/aws/sdk/ec2.clj
@@ -7,6 +7,7 @@
   specify an API endpoint (i.e. region) other than us-east."
 
   (:import com.amazonaws.AmazonServiceException
+           com.amazonaws.auth.DefaultAWSCredentialsProviderChain
            com.amazonaws.auth.BasicAWSCredentials
            com.amazonaws.services.ec2.AmazonEC2Client
            com.amazonaws.services.ec2.model.BlockDeviceMapping
@@ -48,12 +49,12 @@
 
 (defn- ec2-client*
   "Create an AmazonEC2Client instance from a map of credentials."
-  [cred]
-  (let [client (AmazonEC2Client.
-                (BasicAWSCredentials.
-                 (:access-key cred)
-                 (:secret-key cred)))]
-    (if (:endpoint cred) (.setEndpoint client (:endpoint cred)))
+  [{:keys [access-key secret-key endpoint]}]
+  (let [credentials (if (and access-key secret-key)
+                      (BasicAWSCredentials. access-key secret-key)
+                      (DefaultAWSCredentialsProviderChain.))
+        client (AmazonEC2Client. credentials)]
+    (if endpoint (.setEndpoint client endpoint))
     client))
 
 (def ^{:private true}


### PR DESCRIPTION
It is probably best to use the DefaultCredentialProviderChain for authentication as it allows use of environment variables, IAM roles and credential files.  I would take out the BasicAWSCredentials provider completely but have left it in for back compatibility.
see http://docs.aws.amazon.com/AWSSdkDocsJava/latest/DeveloperGuide/credentials.html

Had to remove the licence file mapping as it is no longer present in the latest SDK

Also increased the version of clojure to 1.6.0 and aws sdk to 1.8.9.1.

I increased the version of the jar to 0.5.0 since I haven't tested that the latest SDK works for all methods.
